### PR TITLE
Used a typed enum to indicate state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+watchdog

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -85,5 +85,5 @@ func Checksite(url string) Status {
 // LogState will log a struct of the state of the url, and other important info
 // Just prints the struct but later on could save to a database.
 func LogState(status Status, url string) {
-	fmt.Printf("%#v\n", status)
+	log.Printf("%v is %v", status.Name, status.State)
 }

--- a/main.go
+++ b/main.go
@@ -17,8 +17,9 @@ const (
 )
 
 type Status struct {
-	State State
-	time  time.Time
+	State     State
+	Name      string
+	Timestamp time.Time
 }
 
 func main() {
@@ -44,22 +45,26 @@ func check(url string, wg *sync.WaitGroup) {
 
 // Checksite will get a respone and error from a url and return the status of it.
 // If any errors are encountered, expect 200, it's assumed that the site is down.
-func Checksite(url string) State {
+func Checksite(url string) Status {
+	status := Status{Name: url, Timestamp: time.Now()}
+
 	respone, err := http.Get(url)
 	// TODO: inspect what error the page returns
 	if err != nil {
-		return STATE_DOWN
+		status.State = STATE_DOWN
+		return status
 	}
 	if respone.StatusCode == 200 {
-		return STATE_UP
+		status.State = STATE_UP
 	} else {
-		return STATE_UNKNOWN
+		status.State = STATE_UNKNOWN
 	}
+
+	return status
 }
 
 // LogState will log a struct of the state of the url, and other important info
 // Just prints the struct but later on could save to a database.
-func LogState(state State, url string) {
-	now := time.Now()
-	fmt.Println(url, Status{State: state, time: now})
+func LogState(status Status, url string) {
+	fmt.Println(url, status)
 }

--- a/main.go
+++ b/main.go
@@ -1,20 +1,29 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
-    "fmt"
-    "time"
+	"time"
 )
 
-type status struct {
-    state string
-    time time.Time
+// State is an enum which represents the current state of a resource.
+type State int
+
+const (
+	STATE_UP = iota
+	STATE_DOWN
+	STATE_UNKNOWN
+)
+
+type Status struct {
+	State State
+	time  time.Time
 }
 
 func main() {
-    // The urls that will be checked when run
-	urls := []string {
+	// The urls that will be checked when run
+	urls := []string{
 		"http://134.7.57.175:8090/",
 		"www.curtinmotorsport.com",
 	}
@@ -35,22 +44,22 @@ func check(url string, wg *sync.WaitGroup) {
 
 // Checksite will get a respone and error from a url and return the status of it.
 // If any errors are encountered, expect 200, it's assumed that the site is down.
-func Checksite(url string) (string) {
+func Checksite(url string) State {
 	respone, err := http.Get(url)
 	// TODO: inspect what error the page returns
 	if err != nil {
-		return "Down"
+		return STATE_DOWN
 	}
-    if respone.StatusCode == 200 {
-        return "Up"
-    } else {
-        return "Unknown"
+	if respone.StatusCode == 200 {
+		return STATE_UP
+	} else {
+		return STATE_UNKNOWN
 	}
 }
 
 // LogState will log a struct of the state of the url, and other important info
 // Just prints the struct but later on could save to a database.
-func LogState(state string, url string) {
-    now := time.Now()
-    fmt.Println(url, status{state: state, time: now})
+func LogState(state State, url string) {
+	now := time.Now()
+	fmt.Println(url, Status{State: state, time: now})
 }

--- a/main.go
+++ b/main.go
@@ -10,12 +10,31 @@ import (
 // State is an enum which represents the current state of a resource.
 type State int
 
+func (s State) String() string {
+	switch s {
+	case StateUp:
+		return "up"
+	case StateDown:
+		return "down"
+	case StateUnknown:
+		return "unknown"
+	default:
+		panic("Unknown state")
+	}
+}
+
 const (
-	STATE_UP = iota
-	STATE_DOWN
-	STATE_UNKNOWN
+	// StateUp represents a service which is currently up and responding.
+	StateUp = iota
+
+	// StateDown is a service which isn't responding.
+	StateDown
+
+	// StateUnknown means a service is in an unknown state.
+	StateUnknown
 )
 
+// Status represents the state of a service at a particular point in time.
 type Status struct {
 	State     State
 	Name      string
@@ -51,13 +70,13 @@ func Checksite(url string) Status {
 	respone, err := http.Get(url)
 	// TODO: inspect what error the page returns
 	if err != nil {
-		status.State = STATE_DOWN
+		status.State = StateDown
 		return status
 	}
 	if respone.StatusCode == 200 {
-		status.State = STATE_UP
+		status.State = StateUp
 	} else {
-		status.State = STATE_UNKNOWN
+		status.State = StateUnknown
 	}
 
 	return status
@@ -66,5 +85,5 @@ func Checksite(url string) Status {
 // LogState will log a struct of the state of the url, and other important info
 // Just prints the struct but later on could save to a database.
 func LogState(status Status, url string) {
-	fmt.Println(url, status)
+	fmt.Printf("%#v\n", status)
 }


### PR DESCRIPTION
I thought it'd be a better idea to use an enum to represent a service's state instead of just letting it be stringly typed. That way later on when you want to check what state something is in you don't have to deal with string comparing and error handling.

I added the `State` type (which is effectively just an alias for an `int`), then added the `String()` method to it. This is the method used by `fmt.Printf()` when it is printing the string representation of something.

I also thought it'd be a good idea for the `Checksite()` function to construct and return a `Status` struct instead of just returning the state. It kinda makes more sense, because `Checksite()` is meant to figure out the status of some service at a point in time.

@HarryOsbourne please review this PR and let me know if there's anything which needs to be changed.